### PR TITLE
Add code fence parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Usage of slatemess:
         Print debug info
   -dry
         Will not send the payload to slack but print a curl command equivalent, with the computed payload
+  -fence
+        embed the text in a code fence, so it will be displayed as a code block
   -file string
         Provide a message by file
   -hook string
@@ -107,6 +109,10 @@ slatemess -file samples/blocks -user slatemess -icon :ok_hand: -hook <hook_url>
 **WARNING**: If a template contains a valid field `icon_emoji`, `channel` or `username` these won't be overwritten and will override any value passed by environment or parameters.
 
 **WARNING**: Once a message is detected as json it will be sent as is, but completed with `icon_emoji`, `channel` and `username` if aren't already present. That won't restrain you from sending an invalid message to slack that won't produce any message.
+
+### Using code output for simple messages
+
+Using the parameter `-fence` will enclose the message in code fences so it will be displayed as a code block. But note that if you intended it to be a valid json payload, the code fences will convert it to a basic message and it will be displayed as is.
 
 ### Output as Curl
 

--- a/slatemess.go
+++ b/slatemess.go
@@ -47,14 +47,14 @@ func fenceIt(text string) string {
 
 func (c config) verifyConfig() error {
 	if c.message == "" {
-		return fmt.Errorf("Missing Message")
+		return fmt.Errorf("missing message")
 	}
 	u, err := url.Parse(c.hook)
 	if err != nil {
-		return fmt.Errorf("Error in url %v: %v", c.hook, err)
+		return fmt.Errorf("error in url %v: %v", c.hook, err)
 	}
 	if u.Scheme != "https" {
-		return fmt.Errorf("Invalid Hook, invalid scheme %v", u.Scheme)
+		return fmt.Errorf("invalid hook, invalid scheme %v", u.Scheme)
 	}
 	return nil
 }
@@ -101,11 +101,11 @@ func messageRender(message string) (string, error) {
 	var render bytes.Buffer
 	t, err := template.New("message").Parse(message)
 	if err != nil {
-		return "", fmt.Errorf("Error rendering slack template: %v", err)
+		return "", fmt.Errorf("error rendering slack template: %v", err)
 	}
 	err = t.Execute(&render, dictEnviron())
 	if err != nil {
-		return "", fmt.Errorf("Error generating slack payload: %v", err)
+		return "", fmt.Errorf("error generating slack payload: %v", err)
 	}
 	return render.String(), nil
 }
@@ -172,7 +172,7 @@ func toSlack(hook, payload string) error {
 		SetBody(payload).
 		Post(hook)
 	if err != nil {
-		return fmt.Errorf("Error sending message %v", err)
+		return fmt.Errorf("error sending message %v", err)
 	}
 	if res.IsError() {
 		return fmt.Errorf("slack api returned an error %v \"%v\"", res.Status(), string(res.Body()))

--- a/slatemess.go
+++ b/slatemess.go
@@ -41,6 +41,10 @@ func readStdin() string {
 	return text
 }
 
+func fenceIt(text string) string {
+	return "```" + text + "```"
+}
+
 func (c config) verifyConfig() error {
 	if c.message == "" {
 		return fmt.Errorf("Missing Message")
@@ -240,6 +244,7 @@ func main() {
 	messageArg := flag.String("message", "", "Provide a message by parameter")
 	fileArg := flag.String("file", "", "Provide a message by file")
 	debugArg := flag.Bool("debug", false, "Print debug info")
+	fenceArg := flag.Bool("fence", false, "embed the text in a code fence, so it will be displayed as a code block")
 	dryArg := flag.Bool("dry", false, "Will not send the payload to slack but print a curl command equivalent, with the computed payload")
 	flag.Parse()
 
@@ -283,6 +288,9 @@ func main() {
 		}
 		cfg.message = msg
 
+	}
+	if *fenceArg {
+		cfg.message = fenceIt(cfg.message)
 	}
 	logDebug.Printf("Message: %#v", cfg)
 	err = cfg.verifyConfig()


### PR DESCRIPTION
fixes #1 


This will add a code fence around the text:

```
11:59:01 $ uptime | ./slatemess 
11:59:14 $ uptime | ./slatemess -fence
```

![image](https://user-images.githubusercontent.com/136464/137622329-63998ab1-61cc-462e-8c01-abb274a58104.png)
